### PR TITLE
Refactor and fix fusion paths more

### DIFF
--- a/cupy/_core/_fusion_variable.pyx
+++ b/cupy/_core/_fusion_variable.pyx
@@ -171,12 +171,13 @@ class _TraceScalar(_TraceVariable):
 
     # TODO(asi1024): Remove index argument.
     def __init__(
-            self, index, serial_number, dtype, input_index=None, *,
+            self, index, serial_number, dtype, sctype, input_index=None, *,
             const_value=None,):
         super().__init__(
             index, serial_number, dtype, (), (), input_index, None)
 
         self.const_value = const_value
+        self.pytype = sctype if sctype in (int, float, complex) else False
 
     @property
     def var_name(self):

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -141,7 +141,7 @@ cdef class _Ops:
         _Ops out_ops)
 
     cpdef _Op _guess_routine_from_in_types(
-        self, tuple in_types, tuple weaks, object can_cast=*)
+        self, tuple in_types, tuple weaks=*, object can_cast=*)
 
     cpdef _Op _guess_routine_from_dtype(self, object dtype)
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -10,7 +10,6 @@ from cupy import _util
 cimport cython  # NOQA
 
 from libcpp cimport vector
-from libc.stdint cimport uint64_t, int64_t
 
 from cupy.cuda cimport device
 from cupy.cuda cimport function
@@ -1097,7 +1096,9 @@ cdef inline int _get_kind_score(type kind):
     return 3
 
 
-cdef inline bint _check_should_use_weak_scalar(tuple in_types, tuple weaks) except? -1:
+cdef inline bint _check_should_use_weak_scalar(
+    tuple in_types, tuple weaks
+) except? -1:
     """The promotion strategy of finding the first matching loop is not
     equipped to deal with correct promotion when mixing weak scalars and
     arrays/strong types.
@@ -1107,8 +1108,8 @@ cdef inline bint _check_should_use_weak_scalar(tuple in_types, tuple weaks) exce
     This prevents e.g. `uint8(1) + 0.` from picking a float64 loop.
     """
     cdef int kind, max_array_kind, max_scalar_kind
-    cdef bint all_scalars
-    all_scalars = True
+    cdef bint all_scalars_or_arrays
+
     max_array_kind = -1
     max_scalar_kind = -1
     for in_t, w_t in zip(in_types, weaks):
@@ -1625,7 +1626,7 @@ cdef class _Ops:
             for i in range(len(in_args)):
                 if weaks[i] is not int:
                     continue
-                # Note: For simplicity, check even if output is actually a float
+                # Note: For simplicity, check even if `in_type` is e.g. float
                 integer_argument = int(in_args[i])
                 in_type = op.in_types[i]
                 in_type(integer_argument)  # Check if user input fits loop
@@ -1638,7 +1639,8 @@ cdef class _Ops:
                         (dtype, name))
 
     cpdef _Op _guess_routine_from_in_types(
-            self, tuple in_types, tuple weaks=None, object can_cast=_numpy_can_cast
+            self, tuple in_types, tuple weaks=None,
+            object can_cast=_numpy_can_cast
     ):
         cdef _Op op
         cdef tuple op_types

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1087,7 +1087,7 @@ cdef dict _mst_unsigned_to_signed = {
 
 
 cdef inline int _get_kind_score(type kind):
-    if issubclass(kind, bool):
+    if issubclass(kind, numpy.bool_):
         return 0
     if issubclass(kind, (numpy.integer, int)):
         return 1

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1646,19 +1646,19 @@ cdef class _Ops:
             for i in range(n):
                 it = in_types[i]
                 ot = op_types[i]
-                is_weak = weaks[i]
+                weak_t = weaks[i]
 
                 # XXX: Remove assert (reachable only for pre NEP 50 logic)
                 assert(not isinstance(it, tuple))
 
                 if not can_cast(it, ot):
-                    if not is_weak:
+                    if not weak_t:
                         break
 
                     # If `result_type` doesn't return `ot` then the weak
                     # scalar caused promotion and operand cannot be used.
                     try:
-                        if numpy.result_type(is_weak(0), ot) != ot:
+                        if numpy.result_type(weak_t(0), ot) != ot:
                             break
                     except TypeError:
                         break

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -625,7 +625,7 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
         cdef _kernel._Op op
 
         # XXX: weaks
-        weaks = tuple([False for _ in in_args])
+        weaks = None
         op = self._ops.guess_routine(
             self.name, self._routine_cache, in_args, weaks, dtype, self._ops)
         map_expr, reduce_expr, post_map_expr, reduce_type = op.routine

--- a/cupy/_core/_routines_math.pyx
+++ b/cupy/_core/_routines_math.pyx
@@ -1041,9 +1041,12 @@ _subtract = create_arithmetic(
 # `cupy.arange(3, dtype=cp.uint8) / (-2)`. It would select the 'BB->d' loop,
 # and the kernel would have a declaration `uint8_t in1;`, this converts
 # -2 to uint8_t at initialization (modulo UINT8_MAX, likely).
+# The family of qq loops is a work-around to achieve almost correct promotion.
+# TODO(seberg): Per-ufunc promotion or per-loop type resolution is probably
+#               needed for a full fix.
 _true_divide = create_ufunc(
     'cupy_true_divide',
-    ('qq->d', 'QQ->d',
+    ('qq->d', 'qQ->d', 'Qq->d', 'QQ->d',
      'ee->e', 'ff->f', 'dd->d', 'FF->F', 'DD->D'),
     'out0 = static_cast<out0_type>(in0) / static_cast<out0_type>(in1)',
     doc='''Elementwise true division (i.e. division as floating values).

--- a/cupyx/jit/_cuda_typerules.py
+++ b/cupyx/jit/_cuda_typerules.py
@@ -153,9 +153,9 @@ def guess_routine(
     if dtype is not None:
         return ufunc._ops._guess_routine_from_dtype(dtype)
     can_cast = numpy.can_cast if mode == 'numpy' else _cuda_can_cast
-    weaks = tuple([False for _ in in_types])
+
     return ufunc._ops._guess_routine_from_in_types(
-        tuple(in_types), weaks, can_cast
+        tuple(in_types), None, can_cast
     )
 
 


### PR DESCRIPTION
When I suggested to use `result_type`, I indeed missed that we still need the "use min scalar" logic to some degree, since otherwise a linear loop search can't possibly work.

Not sure about the changes allowing `weaks=None`, but seems not too bad?

Fixing the use of `in_types[i]` rather than `out_types[0]` during the coercion step made some true-div tests fail, so I had to add additional loops unfortunately.

---

I have only run the `cupy_tests/core_tests` as of now, but these are the remaining failures:
```
FAILED tests/cupy_tests/core_tests/fusion_tests/test_misc.py::TestFusionComposition::test_composition - AssertionError: ndarrays of different dtypes are returned.
FAILED tests/cupy_tests/core_tests/fusion_tests/test_misc.py::TestFusionCompile::test_clear_cache - AssertionError: ndarrays of different dtypes are returned.
FAILED tests/cupy_tests/core_tests/fusion_tests/test_array.py::TestFusionArrayOperator_param_12_{func=<lambda>, left_value='array', name='sub', right_value='primitive'}::test_operator - AssertionError: 
```

which seems like an improvement to what you reported in the cupy PR.